### PR TITLE
gates dependent on learnable parameters theta.

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -36,3 +36,21 @@ for feature_idx in range(p):
     circuit.ry( 2*np.pi*sample[feature_idx], data_register[feature_idx])
 
 print(circuit)
+
+
+n_params = p
+theta = 2*np.pi*np.random.uniform(size=n_params)
+
+for i in range(n_params):
+    circuit.rx(theta[i], data_register[i])
+
+
+end = int((n_params+1)/2)
+print("stop at i = {}".format(end))
+for i in range(1, end):
+    j = 2*i-2
+    k = 2*i-1
+    print(j, k)
+    circuit.cx(data_register[j], data_register[k])
+
+print(circuit)


### PR DESCRIPTION
Previous commit was slightly off in problem number, this is problem b,
previous was a.

This problem encompasses encoding quantum gates dependent on learnable
parameters. The number of such should be arbitrary (should proobably be
even numbers however, due to the pairwise coupling of the gates.

I suspect there is a mismatch between my understainding and the expected
one, as the number of trainable parameters ϴ should be arbitraty, while
the number of features are referred to as the "p first" parameters. The
number of parameters ϴ and p differs in the examples given as well.

So far, I think I can only acknowledge this and try to implement the
code as best I can and anticipate changes.